### PR TITLE
Update the header styling so the logo is no longer broken

### DIFF
--- a/Forside.html
+++ b/Forside.html
@@ -13,11 +13,11 @@
 </head>
 
 
-<body class="container">
-
+<body>
+  <main class="container">
     <!-- Menubar-->
 
-    <header class="header__grid">
+    <header class="header header__grid">
         <div class="dropdown">
             <button class="dropbtn"><i class="fa fa-bars" style="font-size:25pt; #e20019"></i></button>
             <div class="dropdown-content">
@@ -28,13 +28,13 @@
             </div>
         </div>
 
-        <a href="Forside.html"> <img class="logo" src="Billeder/Logo1.jpg" alt="Amo hvedemel logo"> </a>
+        <a href="Forside.html"> <img class="logo" src="Logo1.jpg" alt="Amo hvedemel logo"> </a>
     </header>
 
     <!--menubar slut -->
     <section class="indhold">
         <div class="banner__grid">
-            <img class=" billeder" src="Billeder/banner.jpg" alt="Amo hvedemel banner">
+            <img class="billeder" src="banner.jpg" alt="Amo hvedemel banner">
         </div>
 
         <div class="indhold__grid">
@@ -43,7 +43,7 @@
         </div>
 
         <div class="tekstboks opskrifter__grid">
-            <img src="Billeder/Dagens%20opskrift.jpg" alt="Nature" style="width:100%;">
+            <img src="Dagens%20opskrift.jpg" alt="Nature" style="width:100%;">
             <div class="tekst__blok broedtekst">
                 <h2 class="billedetekst ">Lækre brunchpandekager</h2>
 
@@ -60,27 +60,27 @@
         <section class="galleri__grid">
             <div class="gallery">
                 <a target="_blank" href="fjords.jpg">
-                    <img src="Billeder/Burger.jpg" alt="Cinque Terre">
+                    <img src="Burger.jpg" alt="Cinque Terre">
                 </a>
                 <div class="galleri__tekst">Bløde hjemmebagte burgerboller </div>
             </div>
 
             <div class="left">
                 <a target="_blank" href="forest.jpg">
-                    <img src="Billeder/croissant.jpg" alt="Forest">
+                    <img src="croissant.jpg" alt="Forest">
                 </a>
                 <div class="galleri__tekst">Sprøde hjemmelavede croissants</div>
             </div>
 
             <div class="gallery">
                 <a target="_blank" href="lights.jpg">
-                    <img src="Billeder/smaakager.jpg" alt="Northern Lights">
+                    <img src="smaakager.jpg" alt="Northern Lights">
                 </a>
                 <div class="galleri__tekst">Vaniljecookies med chokolades</div>
             </div>
             <div class="left">
                 <a target="_blank" href="mountains.jpg">
-                    <img src="Billeder/taerte.jpg" alt="Mountains">
+                    <img src="taerte.jpg" alt="Mountains">
                 </a>
                 <div class="galleri__tekst ">Italiensk citrontærte med marengs</div>
             </div>
@@ -112,7 +112,7 @@
         </section>
         <footer class="footer__grid footer">
             <div>
-                <img class="billeder" src="Billeder/hvede.jpg" alt="Hvede">
+                <img class="billeder" src="hvede.jpg" alt="Hvede">
 
                 <div class="footer__indhold">
                     <h4>Kontakt</h4>
@@ -129,6 +129,7 @@
             </div>
         </footer>
     </section>
+  </main>
 </body>
 
 </html>

--- a/style.css
+++ b/style.css
@@ -29,9 +29,8 @@
 }
 
 .header__grid {
-    grid-area: header;
-
-
+  width: 100%;
+  grid-area: header;
 }
 
 .banner__grid {
@@ -83,21 +82,11 @@
 
 /* ------ menubar-----*/
 
-header {
-
+.header {
     font-family: itc-american-typewriter-cond, serif;
     font-weight: 700;
     font-style: normal;
     font-size: 16pt;
-    z-index: 1;
-    overflow: hidden;
-    position: fixed;
-    top: 0;
-    width: 100%;
-    height: 85px;
-    background-color: white;
-
-
 }
 
 
@@ -378,7 +367,7 @@ footer li {
 
 
 
-    header {
+    /* header {
 
         font-family: bello-pro, sans-serif;
         font-weight: 400;
@@ -394,7 +383,7 @@ footer li {
         background-color: white;
 
 
-    }
+    } */
     /*navbar*/
     
     /*skal være siplay none*/


### PR DESCRIPTION
I did a few things here.

1) Added the container class to a new `main` element. In practice this is better.

2) Removed `Billeder/` from the img src attribute. (Not sure of your setup but you might need to put that back in)

Give it a look, see if it's what you're looking for. 

![image](https://user-images.githubusercontent.com/780469/49597012-93a82800-f949-11e8-9bbb-d9f42753c662.png)

